### PR TITLE
Create readbyteserial

### DIFF
--- a/macros/readbyteserial
+++ b/macros/readbyteserial
@@ -1,0 +1,8 @@
+function buf=readserial(h,n)
+// 12/1/2009: corrected version after report of bug 3829  
+   if ~exists("n","local") then
+     N=serialstatus(h); n=N(1)
+   end
+   TCL_EvalStr("binary scan [read "+h+" "+string(n)+"] cu* ttybuf")
+   buf=evstr(TCL_GetVar("ttybuf"));//returns an array of bytes instead of char, useful since scilab does not want to cast strings into matrixes
+endfunction


### PR DESCRIPTION
this is quite useful for making matrixes out of serial input, because scilab cant cast strings into matrixes (yet)
