### PR TITLE
Feature eval is obsolete

### DIFF
--- a/macros/closeserial.sci
+++ b/macros/closeserial.sci
@@ -1,4 +1,4 @@
 function result=closeserial(h)
-  TCL_EvalStr("set closeresult [catch {close "+string(h)+"}]"); 
-  result=-evstr(TCL_GetVar("closeresult"));
+  TCL_EvalStr("set closeresult [catch {close " + h + "}]"); 
+  result = -evstr(TCL_GetVar("closeresult"));
 endfunction

--- a/macros/closeserial.sci
+++ b/macros/closeserial.sci
@@ -1,4 +1,4 @@
 function result=closeserial(h)
   TCL_EvalStr("set closeresult [catch {close "+string(h)+"}]"); 
-  result=-eval(TCL_GetVar("closeresult"));
+  result=-evstr(TCL_GetVar("closeresult"));
 endfunction


### PR DESCRIPTION
WARNING: Feature eval is obsolete.
WARNING: Please use evstr() instead.
WARNING: This feature will be permanently removed in Scilab 6.1


on a side note, why using eval or evstr at all?