### PR TITLE
to accept com ports higher than 9

### DIFF
--- a/macros/openserial.sci
+++ b/macros/openserial.sci
@@ -4,7 +4,7 @@ function h=openserial(p,smode,translation,handshake,xchar,timeout)
   if type(p)==1 | type(p)==8 then
     if p<=0 then error("port number must be greater than zero"); end
     if getos() == "Windows" then
-      port="COM"+string(p)+":"
+      port = "\\\\.\\com" + string(p)
     else
       port="/dev/ttyS"+string(p-1)
     end


### PR DESCRIPTION
`\\\\.\\com*` to accept com ports higher than 9. the `com*:` is legacy.